### PR TITLE
feat: merge confidential-nix-config (TMEN0081 corporate Mac)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-merge-confidential-nix-config.md
+++ b/docs/superpowers/plans/2026-04-28-merge-confidential-nix-config.md
@@ -1,0 +1,527 @@
+# Merge confidential-nix-config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge the corporate-Mac portion of `~/Workspaces/confidential-nix-config` into `~/Workspaces/nix-config` so the corporate PC can rebuild from the public repo.
+
+**Architecture:** Add `nix-darwin` as a flake input. Bring over the `TMEN0081` host (system + home) and the four reusable darwin modules (aerospace, fonts, docker, zsh). Inline the four single-host darwin app modules (vivaldi, postman, sequel-ace, ukelele) directly into the host config per the project's "no needless modularization" rule. Public modules and the `m5p01`/`xanthus`/`helios` hosts are untouched.
+
+**Tech Stack:** Nix flakes, snowfall-lib, nix-darwin, home-manager.
+
+**Validation:** No unit tests apply — the gates are `nix flake check` (evaluation) and `darwin-rebuild build --flake .#TMEN0081` (build), the latter only runnable on the corporate Mac.
+
+---
+
+## File Structure
+
+**Created:**
+- `modules/darwin/windowManager/aerospace/default.nix`
+- `modules/darwin/windowManager/aerospace/autoraise.nix`
+- `modules/darwin/system/fonts/default.nix`
+- `modules/darwin/app/dev/docker/default.nix`
+- `modules/darwin/app/dev/zsh/default.nix`
+- `systems/aarch64-darwin/TMEN0081/default.nix`
+- `systems/aarch64-darwin/TMEN0081/keyboard.nix`
+- `systems/aarch64-darwin/TMEN0081/symbolichotkeys2nix.py`
+- `homes/aarch64-darwin/usr0200797@TMEN0081/default.nix`
+
+**Modified:**
+- `flake.nix` — add `darwin` input.
+
+---
+
+## Task 1: Add nix-darwin flake input
+
+**Files:**
+- Modify: `flake.nix`
+
+- [ ] **Step 1: Edit `flake.nix` to add the `darwin` input**
+
+Insert after the `home-manager` input block (currently lines covering `home-manager = { url = ...; inputs.nixpkgs.follows = "nixpkgs"; };`):
+
+```nix
+    darwin = {
+      url = "github:lnl7/nix-darwin/nix-darwin-25.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+```
+
+- [ ] **Step 2: Verify the flake still evaluates**
+
+Run: `nix flake check --no-build`
+Expected: PASS (no new systems yet, just the input addition).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flake.nix flake.lock
+git commit -m "feat(flake): add nix-darwin input for darwin host support"
+```
+
+---
+
+## Task 2: Add reusable darwin modules
+
+**Files:**
+- Create: `modules/darwin/windowManager/aerospace/default.nix`
+- Create: `modules/darwin/windowManager/aerospace/autoraise.nix`
+- Create: `modules/darwin/system/fonts/default.nix`
+- Create: `modules/darwin/app/dev/docker/default.nix`
+- Create: `modules/darwin/app/dev/zsh/default.nix`
+
+These modules come verbatim from `~/Workspaces/confidential-nix-config`. None of them are tweaked.
+
+- [ ] **Step 1: Create `modules/darwin/windowManager/aerospace/default.nix`**
+
+```nix
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  cfg = config.capybara.windowManager.aerospace;
+in {
+  options.capybara.windowManager.aerospace = {
+    enable = mkBoolOpt false "Whether to enable the aerospace";
+  };
+
+  imports = [./autoraise.nix];
+
+  config = mkIf cfg.enable {
+    services.aerospace = let
+      aerospace = pkgs.aerospace;
+    in {
+      enable = true;
+      package = aerospace;
+      settings = {
+        default-root-container-layout = "tiles";
+        default-root-container-orientation = "horizontal";
+        on-focus-changed = ["move-mouse window-lazy-center"];
+        exec-on-workspace-change = ["/usr/bin/env" "bash" "-c" "${aerospace}/bin/aerospace move-mouse window-lazy-center"];
+        workspace-to-monitor-force-assignment = {
+          "1" = "main";
+          "2" = "main";
+          "3" = "main";
+          "4" = "main";
+          "5" = "main";
+          "6" = "main";
+          "7" = "main";
+          "8" = "main";
+          "9" = "main";
+          "10" = "main";
+          "11" = 1;
+          "12" = 3;
+        };
+        mode.main.binding = {
+          alt-enter = "exec-and-forget open -n -a kitty";
+          alt-b = "exec-and-forget open -n -a vivaldi";
+          alt-shift-q = "close --quit-if-last-window";
+          alt-j = "focus --ignore-floating left";
+          alt-k = "focus --ignore-floating right";
+          alt-h = "focus-monitor prev";
+          alt-l = "focus-monitor next";
+          alt-shift-j = "move left";
+          alt-shift-k = "move right";
+          alt-shift-h = "move-node-to-monitor --focus-follows-window prev";
+          alt-shift-l = "move-node-to-monitor --focus-follows-window next";
+          alt-f = "fullscreen";
+          alt-1 = "workspace 1";
+          alt-2 = "workspace 2";
+          alt-3 = "workspace 3";
+          alt-4 = "workspace 4";
+          alt-5 = "workspace 5";
+          alt-6 = "workspace 6";
+          alt-7 = "workspace 7";
+          alt-8 = "workspace 8";
+          alt-9 = "workspace 9";
+          alt-0 = "workspace 10";
+          alt-shift-1 = "move-node-to-workspace --focus-follows-window 1";
+          alt-shift-2 = "move-node-to-workspace --focus-follows-window 2";
+          alt-shift-3 = "move-node-to-workspace --focus-follows-window 3";
+          alt-shift-4 = "move-node-to-workspace --focus-follows-window 4";
+          alt-shift-5 = "move-node-to-workspace --focus-follows-window 5";
+          alt-shift-6 = "move-node-to-workspace --focus-follows-window 6";
+          alt-shift-7 = "move-node-to-workspace --focus-follows-window 7";
+          alt-shift-8 = "move-node-to-workspace --focus-follows-window 8";
+          alt-shift-9 = "move-node-to-workspace --focus-follows-window 9";
+          alt-shift-0 = "move-node-to-workspace --focus-follows-window 10";
+        };
+      };
+    };
+  };
+}
+```
+
+- [ ] **Step 2: Create `modules/darwin/windowManager/aerospace/autoraise.nix`**
+
+```nix
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara;
+{
+  config = let
+    package = pkgs.autoraise;
+  in {
+    environment.systemPackages = [package];
+
+    launchd.user.agents.autoraise.serviceConfig = {
+      ProgramArguments = ["${package}/bin/autoraise" "-disableKey" "disabled"];
+      KeepAlive = true;
+      RunAtLoad = true;
+    };
+  };
+}
+```
+
+- [ ] **Step 3: Create `modules/darwin/system/fonts/default.nix`**
+
+```nix
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  cfg = config.capybara.system.fonts;
+in {
+  options.capybara.system.fonts = {
+    enable = mkBoolOpt false "Whether to enable the fonts";
+  };
+
+  config = mkIf cfg.enable {
+    fonts.packages = with pkgs; [
+      noto-fonts
+      noto-fonts-cjk-sans
+      noto-fonts-color-emoji
+      nerd-fonts.jetbrains-mono
+    ];
+  };
+}
+```
+
+- [ ] **Step 4: Create `modules/darwin/app/dev/docker/default.nix`**
+
+```nix
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  cfg = config.capybara.app.dev.docker;
+in {
+  options.capybara.app.dev.docker = {
+    enable = mkBoolOpt false "Whether to enable the docker";
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.homebrew.enable;
+        message = "Homebrew has to be enabled to install this";
+      }
+    ];
+
+    homebrew.brews = ["docker" "colima"];
+  };
+}
+```
+
+- [ ] **Step 5: Create `modules/darwin/app/dev/zsh/default.nix`**
+
+```nix
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  user-names = builtins.attrNames config.snowfallorg.users;
+  zshEnabled = any (name: config.home-manager.users.${name}.capybara.app.dev.zsh.enable) user-names;
+in {
+  config = mkIf zshEnabled {
+    environment.etc."zshrc".text = ''
+      ${optionalString config.homebrew.enable "eval \"$(${config.homebrew.brewPrefix}/brew shellenv)\""}
+    '';
+  };
+}
+```
+
+- [ ] **Step 6: Verify evaluation**
+
+Run: `nix flake check --no-build`
+Expected: PASS. Modules exist but are unused (no darwin host yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add modules/darwin
+git commit -m "feat(darwin): add aerospace, fonts, docker, zsh modules"
+```
+
+---
+
+## Task 3: Add TMEN0081 system config
+
+**Files:**
+- Create: `systems/aarch64-darwin/TMEN0081/default.nix`
+- Create: `systems/aarch64-darwin/TMEN0081/keyboard.nix`
+- Create: `systems/aarch64-darwin/TMEN0081/symbolichotkeys2nix.py`
+
+The host config inlines the four single-host homebrew apps (vivaldi, postman, sequel-ace, ukelele) per the project's "no needless modularization" rule. The four modules in confidential each just add one homebrew cask/brew, so they collapse to a single `homebrew.casks` list.
+
+- [ ] **Step 1: Create the host directory**
+
+```bash
+mkdir -p systems/aarch64-darwin/TMEN0081
+```
+
+- [ ] **Step 2: Create `systems/aarch64-darwin/TMEN0081/default.nix`**
+
+```nix
+{lib, ...}:
+with lib;
+with lib.capybara; {
+  imports = [./keyboard.nix];
+
+  config = {
+    nix.enable = false;
+
+    homebrew = enabled;
+    system.primaryUser = "usr0200797";
+
+    homebrew.casks = [
+      "vivaldi"
+      "postman"
+      "sequel-ace"
+      "ukelele"
+    ];
+
+    capybara = {
+      app.dev.docker = enabled;
+      system.fonts = enabled;
+      windowManager.aerospace = enabled;
+    };
+
+    system = {
+      defaults = {
+        NSGlobalDomain = {
+          AppleInterfaceStyle = "Dark";
+          "com.apple.mouse.tapBehavior" = 1;
+        };
+        dock.autohide = true;
+      };
+      keyboard = {
+        enableKeyMapping = true;
+        swapLeftCtrlAndFn = true;
+      };
+    };
+
+    system.stateVersion = 5;
+  };
+}
+```
+
+- [ ] **Step 3: Copy `keyboard.nix` from confidential repo**
+
+```bash
+cp ~/Workspaces/confidential-nix-config/systems/aarch64-darwin/TMEN0081/keyboard.nix \
+   systems/aarch64-darwin/TMEN0081/keyboard.nix
+```
+
+- [ ] **Step 4: Copy `symbolichotkeys2nix.py` helper**
+
+```bash
+cp ~/Workspaces/confidential-nix-config/systems/aarch64-darwin/TMEN0081/symbolichotkeys2nix.py \
+   systems/aarch64-darwin/TMEN0081/symbolichotkeys2nix.py
+```
+
+- [ ] **Step 5: Verify evaluation**
+
+Run: `nix flake check --no-build --show-trace`
+Expected: PASS — `darwinConfigurations.TMEN0081` should now be present (snowfall auto-discovers it). If it fails complaining about missing `darwin` outputs, check Task 1 was applied.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add systems/aarch64-darwin
+git commit -m "feat(systems): add TMEN0081 corporate macOS host"
+```
+
+---
+
+## Task 4: Add TMEN0081 home config
+
+**Files:**
+- Create: `homes/aarch64-darwin/usr0200797@TMEN0081/default.nix`
+
+The home config references shared `modules/home/*` modules; these are linux-developed but are home-manager modules so should work on darwin. Any darwin-incompat issues surface at build time and are addressed in Task 5.
+
+- [ ] **Step 1: Create the home directory**
+
+```bash
+mkdir -p homes/aarch64-darwin/usr0200797@TMEN0081
+```
+
+- [ ] **Step 2: Create `homes/aarch64-darwin/usr0200797@TMEN0081/default.nix`**
+
+```nix
+{lib, ...}:
+with lib;
+with lib.capybara; {
+  capybara = {
+    app = {
+      desktop = {
+        kitty = enabled;
+      };
+      dev = {
+        zsh = enabled;
+        neovim = enabled;
+        git = {
+          enable = true;
+          username = "mtaku3";
+          email = "me@mtaku3.com";
+          signingKey = "EA7E68BE661AE1D8";
+          signByDefault = true;
+        };
+        gpg = enabled;
+        gh = enabled;
+        tmux = enabled;
+        devbox = enabled;
+        claude-code = enabled;
+      };
+    };
+  };
+
+  home.stateVersion = "24.11";
+}
+```
+
+- [ ] **Step 3: Verify evaluation**
+
+Run: `nix flake check --no-build --show-trace`
+Expected: PASS. If it fails citing a shared home module, capture the error — those are the darwin-incompat fixes in Task 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add homes/aarch64-darwin
+git commit -m "feat(homes): add usr0200797@TMEN0081 home config"
+```
+
+---
+
+## Task 5: Build on the corporate Mac and fix darwin incompatibilities
+
+**Files:** depends on what fails. Most likely candidates: `modules/home/app/dev/{gpg,claude-code,tmux,git}/default.nix`, `modules/home/impermanence/default.nix`.
+
+This task can only be performed on the TMEN0081 hardware. On linux the prior tasks pass `nix flake check`; the actual `darwin-rebuild build` is the real gate.
+
+- [ ] **Step 1: On TMEN0081, fetch the branch and try to build**
+
+```bash
+cd ~/Workspaces/nix-config   # or wherever the corporate PC has the checkout
+git fetch origin
+git checkout <merge-branch>
+darwin-rebuild build --flake .#TMEN0081 --show-trace 2>&1 | tee /tmp/darwin-build.log
+```
+
+Expected: likely fails on at least one shared home module that uses linux-only paths or packages.
+
+- [ ] **Step 2: For each failure, fix in the shared module (preferred)**
+
+The fix pattern for a linux-only chunk:
+
+```nix
+config = mkIf cfg.enable (mkMerge [
+  {
+    # cross-platform config here
+  }
+  (mkIf pkgs.stdenv.isLinux {
+    # linux-only config here (e.g., capybara.impermanence.directories)
+  })
+]);
+```
+
+For a linux-only package, swap the package conditional on `pkgs.stdenv.hostPlatform.isDarwin`. Avoid forking the module.
+
+- [ ] **Step 3: Re-run the build**
+
+Run: `darwin-rebuild build --flake .#TMEN0081 --show-trace`
+Expected: PASS, or a new failure to fix. Repeat steps 2–3 until clean.
+
+- [ ] **Step 4: Switch and verify the system works**
+
+Run: `darwin-rebuild switch --flake .#TMEN0081`
+Expected: switch completes, aerospace launches, kitty/git/tmux/etc. work.
+
+- [ ] **Step 5: Commit any darwin-compat fixes**
+
+```bash
+git add modules/home
+git commit -m "fix(home): make shared modules darwin-compatible"
+```
+
+(Skip the commit if no fixes were needed.)
+
+---
+
+## Task 6: Verify cross-host evaluation and merge
+
+**Files:** none modified.
+
+- [ ] **Step 1: From a linux host (helios/m5p01/xanthus), verify nothing regressed**
+
+Run: `nix flake check --show-trace`
+Expected: PASS. All four hosts (`helios`, `m5p01`, `xanthus`, `TMEN0081`) listed under `darwinConfigurations` / `nixosConfigurations`.
+
+- [ ] **Step 2: Push the branch and open a PR (or merge to main)**
+
+```bash
+git push -u origin <merge-branch>
+gh pr create --title "feat: merge confidential-nix-config (TMEN0081)" \
+  --body "Adds nix-darwin support and TMEN0081 corporate Mac host. Spec: docs/superpowers/specs/2026-04-28-merge-confidential-nix-config-design.md"
+```
+
+- [ ] **Step 3: After merge, archive the confidential repo**
+
+On GitHub: navigate to `mtaku3/confidential-nix-config` → Settings → Archive this repository. Do not delete — this preserves history for reference.
+
+- [ ] **Step 4: Update the corporate PC's checkout to point at public**
+
+On TMEN0081:
+
+```bash
+cd ~/Workspaces
+mv confidential-nix-config confidential-nix-config.archived
+# nix-config should already be checked out from public; if not:
+# git clone https://github.com/mtaku3/nix-config.git
+cd nix-config
+git pull
+darwin-rebuild switch --flake .#TMEN0081
+```
+
+Expected: corporate PC now rebuilds from public repo.
+
+---
+
+## Acceptance
+
+- `nix flake check` passes on linux for all hosts.
+- `darwin-rebuild switch --flake .#TMEN0081` succeeds on the corporate Mac.
+- The four pre-existing hosts (`helios`, `m5p01`, `xanthus`) are unchanged in behavior.
+- `mtaku3/confidential-nix-config` is archived.

--- a/docs/superpowers/specs/2026-04-28-merge-confidential-nix-config-design.md
+++ b/docs/superpowers/specs/2026-04-28-merge-confidential-nix-config-design.md
@@ -1,0 +1,104 @@
+# Merge confidential-nix-config into nix-config
+
+## Background
+
+Two nix-config repos exist:
+
+- `~/Workspaces/nix-config` — public, GitHub `mtaku3/nix-config`, source of truth.
+- `~/Workspaces/confidential-nix-config` — private, GitHub `mtaku3/confidential-nix-config`, a stale fork of public plus a corporate darwin host.
+
+The corporate PC currently rebuilds from the confidential repo, but the company now prohibits pulling private repos on corporate machines. The confidential repo's content is not actually sensitive, so the resolution is to merge it into the public repo and retire the private one.
+
+A diff audit confirmed that almost every module difference is the result of public moving ahead (new options, refactors, tailscale→netbird swap, native claude-code installer, etc.) rather than corporate-specific changes. Public is correct; confidential is simply behind.
+
+## Goal
+
+Make `nix-config#TMEN0081` build and switch on the corporate Mac, then archive the confidential repo.
+
+## Scope
+
+Bring over **only what TMEN0081 needs**.
+
+### In
+
+1. New flake input: `darwin = { url = "github:lnl7/nix-darwin/nix-darwin-25.11"; inputs.nixpkgs.follows = "nixpkgs"; };`
+2. `systems/aarch64-darwin/TMEN0081/default.nix` (host config).
+3. `homes/aarch64-darwin/usr0200797@TMEN0081/default.nix` (home config).
+4. Darwin modules referenced by TMEN, split per the project's "no needless modularization" rule:
+   - **Kept as modules** (reusable darwin abstractions):
+     - `modules/darwin/windowManager/aerospace/` (incl. `autoraise.nix`)
+     - `modules/darwin/system/fonts/`
+     - `modules/darwin/app/dev/docker/`
+     - `modules/darwin/app/dev/zsh/`
+   - **Inlined into TMEN0081's `default.nix`** (single-host, one-package installs):
+     - `vivaldi`, `postman`, `sequel-ace`, `ukelele`
+
+### Out
+
+- `kubecerts`, `mcp-servers-nix` flake inputs (TMEN does not use them).
+- All confidential-side variants of public modules (claude-code, git, gpg, kube-cli, tmux, kitty, agenix, docker, kubernetes/*, ssh, suites). Public versions stand.
+- `m5p01` and `xanthus` host configs from confidential — public versions stay authoritative.
+- Migrating the `secrets` submodule (both repos already share `mtaku3/nix-config-secrets`).
+- Preserving git history from confidential (single squash commit; blame for inlined files starts fresh).
+
+## Approach
+
+Work on a feature branch off `main`.
+
+### Step 1 — flake input
+
+Add `darwin` to `flake.nix` inputs alongside `home-manager`, following the existing release-branch pattern.
+
+### Step 2 — copy darwin modules
+
+Copy the four kept darwin module directories verbatim from confidential:
+
+```
+modules/darwin/windowManager/aerospace/{default.nix,autoraise.nix}
+modules/darwin/system/fonts/default.nix
+modules/darwin/app/dev/docker/default.nix
+modules/darwin/app/dev/zsh/default.nix
+```
+
+### Step 3 — system config for TMEN0081
+
+Create `systems/aarch64-darwin/TMEN0081/{default.nix,keyboard.nix,symbolichotkeys2nix.py}`. Start from confidential's version, then inline the four single-host darwin apps so we don't drag in their module wrappers:
+
+- Replace `capybara.app.desktop.vivaldi = enabled;` with a direct `homebrew.casks` (or `environment.systemPackages`) entry — match whatever the original `vivaldi/default.nix` did.
+- Same for `postman`, `sequel-ace`, `ukelele`.
+
+Keep `capybara.app.dev.docker`, `capybara.system.fonts`, `capybara.windowManager.aerospace` as module references.
+
+### Step 4 — home config for TMEN0081
+
+Copy `homes/aarch64-darwin/usr0200797@TMEN0081/default.nix` verbatim. It only references shared `modules/home/*` modules (`kitty`, `zsh`, `neovim`, `git`, `gpg`, `gh`, `tmux`, `devbox`, `claude-code`).
+
+### Step 5 — verify on the corporate Mac
+
+The build can only be validated on darwin hardware. On TMEN0081:
+
+1. `nix flake check` (will exercise both nixos and darwin attrs).
+2. `darwin-rebuild build --flake .#TMEN0081`.
+3. Iterate on any darwin-incompat issue in the shared `modules/home/*` modules. Preferred fix: make the shared module darwin-clean (e.g., guard linux-only paths with `lib.mkIf pkgs.stdenv.isLinux` or use `config.home.homeDirectory`). Avoid forking modules.
+4. `darwin-rebuild switch --flake .#TMEN0081`.
+
+### Step 6 — retire confidential repo
+
+Once the corporate PC is running off public:
+
+- Push the merge branch, open PR, merge to `main`.
+- Update the corporate PC's checkout to point at `mtaku3/nix-config`.
+- Archive `mtaku3/confidential-nix-config` on GitHub (do not delete — keeps history accessible).
+
+## Risks and mitigations
+
+- **Shared home modules may not be darwin-clean.** Modules like `kitty`, `tmux`, `git`, `gpg`, `claude-code` were written and tested on linux. Mitigation: `darwin-rebuild build` is the gate; fix incompatibilities in-module rather than forking.
+- **`capybara.impermanence` references on darwin.** Several home modules (e.g., `gpg`, `claude-code`) call `capybara.impermanence.directories`. The TMEN home config doesn't enable impermanence, so the option must accept being set without impermanence enabled — verify this isn't asserted anywhere. If it is, relax the assertion to `mkIf` on impermanence.enable.
+- **Snowfall auto-discovery of `modules/darwin/`.** Snowfall should pick this up automatically once the `darwin` input is present; if not, may need a small `lib.mkFlake` adjustment. Surface during `nix flake check`.
+
+## Acceptance
+
+- `nix flake check` passes.
+- `darwin-rebuild switch --flake .#TMEN0081` succeeds on the corporate Mac.
+- All previously working hosts (`helios`, `m5p01`, `xanthus`) still evaluate (`nix flake check` covers this).
+- Confidential repo archived; corporate PC pulls from public only.

--- a/flake.lock
+++ b/flake.lock
@@ -43,6 +43,27 @@
         "type": "github"
       }
     },
+    "darwin_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772129556,
+        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "ref": "nix-darwin-25.11",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -337,6 +358,7 @@
     "root": {
       "inputs": {
         "agenix": "agenix",
+        "darwin": "darwin_2",
         "disko": "disko",
         "home-manager": "home-manager_2",
         "impermanence": "impermanence",

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    darwin = {
+      url = "github:lnl7/nix-darwin/nix-darwin-25.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     impermanence.url = "github:nix-community/impermanence";
 
     agenix.url = "github:ryantm/agenix";

--- a/homes/aarch64-darwin/usr0200797@TMEN0081/default.nix
+++ b/homes/aarch64-darwin/usr0200797@TMEN0081/default.nix
@@ -1,0 +1,29 @@
+{lib, ...}:
+with lib;
+with lib.capybara; {
+  capybara = {
+    app = {
+      desktop = {
+        kitty = enabled;
+      };
+      dev = {
+        zsh = enabled;
+        neovim = enabled;
+        git = {
+          enable = true;
+          username = "mtaku3";
+          email = "me@mtaku3.com";
+          signingKey = "EA7E68BE661AE1D8";
+          signByDefault = true;
+        };
+        gpg = enabled;
+        gh = enabled;
+        tmux = enabled;
+        devbox = enabled;
+        claude-code = enabled;
+      };
+    };
+  };
+
+  home.stateVersion = "24.11";
+}

--- a/modules/darwin/app/dev/docker/default.nix
+++ b/modules/darwin/app/dev/docker/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  cfg = config.capybara.app.dev.docker;
+in {
+  options.capybara.app.dev.docker = {
+    enable = mkBoolOpt false "Whether to enable the docker";
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.homebrew.enable;
+        message = "Homebrew has to be enabled to install this";
+      }
+    ];
+
+    homebrew.brews = ["docker" "colima"];
+  };
+}

--- a/modules/darwin/app/dev/zsh/default.nix
+++ b/modules/darwin/app/dev/zsh/default.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  user-names = builtins.attrNames config.snowfallorg.users;
+  zshEnabled = any (name: config.home-manager.users.${name}.capybara.app.dev.zsh.enable) user-names;
+in {
+  config = mkIf zshEnabled {
+    environment.etc."zshrc".text = ''
+      ${optionalString config.homebrew.enable "eval \"$(${config.homebrew.brewPrefix}/brew shellenv)\""}
+    '';
+  };
+}

--- a/modules/darwin/system/fonts/default.nix
+++ b/modules/darwin/system/fonts/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  cfg = config.capybara.system.fonts;
+in {
+  options.capybara.system.fonts = {
+    enable = mkBoolOpt false "Whether to enable the fonts";
+  };
+
+  config = mkIf cfg.enable {
+    fonts.packages = with pkgs; [
+      noto-fonts
+      noto-fonts-cjk-sans
+      noto-fonts-color-emoji
+      nerd-fonts.jetbrains-mono
+    ];
+  };
+}

--- a/modules/darwin/windowManager/aerospace/autoraise.nix
+++ b/modules/darwin/windowManager/aerospace/autoraise.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara;
+{
+  config = let
+    package = pkgs.autoraise;
+  in {
+    environment.systemPackages = [package];
+
+    launchd.user.agents.autoraise.serviceConfig = {
+      ProgramArguments = ["${package}/bin/autoraise" "-disableKey" "disabled"];
+      KeepAlive = true;
+      RunAtLoad = true;
+    };
+  };
+}

--- a/modules/darwin/windowManager/aerospace/default.nix
+++ b/modules/darwin/windowManager/aerospace/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.capybara; let
+  cfg = config.capybara.windowManager.aerospace;
+in {
+  options.capybara.windowManager.aerospace = {
+    enable = mkBoolOpt false "Whether to enable the aerospace";
+  };
+
+  imports = [./autoraise.nix];
+
+  config = mkIf cfg.enable {
+    services.aerospace = let
+      aerospace = pkgs.aerospace;
+    in {
+      enable = true;
+      package = aerospace;
+      settings = {
+        default-root-container-layout = "tiles";
+        default-root-container-orientation = "horizontal";
+        on-focus-changed = ["move-mouse window-lazy-center"];
+        exec-on-workspace-change = ["/usr/bin/env" "bash" "-c" "${aerospace}/bin/aerospace move-mouse window-lazy-center"];
+        workspace-to-monitor-force-assignment = {
+          "1" = "main";
+          "2" = "main";
+          "3" = "main";
+          "4" = "main";
+          "5" = "main";
+          "6" = "main";
+          "7" = "main";
+          "8" = "main";
+          "9" = "main";
+          "10" = "main";
+          "11" = 1;
+          "12" = 3;
+        };
+        mode.main.binding = {
+          alt-enter = "exec-and-forget open -n -a kitty";
+          alt-b = "exec-and-forget open -n -a vivaldi";
+          alt-shift-q = "close --quit-if-last-window";
+          alt-j = "focus --ignore-floating left";
+          alt-k = "focus --ignore-floating right";
+          alt-h = "focus-monitor prev";
+          alt-l = "focus-monitor next";
+          alt-shift-j = "move left";
+          alt-shift-k = "move right";
+          alt-shift-h = "move-node-to-monitor --focus-follows-window prev";
+          alt-shift-l = "move-node-to-monitor --focus-follows-window next";
+          alt-f = "fullscreen";
+          alt-1 = "workspace 1";
+          alt-2 = "workspace 2";
+          alt-3 = "workspace 3";
+          alt-4 = "workspace 4";
+          alt-5 = "workspace 5";
+          alt-6 = "workspace 6";
+          alt-7 = "workspace 7";
+          alt-8 = "workspace 8";
+          alt-9 = "workspace 9";
+          alt-0 = "workspace 10";
+          alt-shift-1 = "move-node-to-workspace --focus-follows-window 1";
+          alt-shift-2 = "move-node-to-workspace --focus-follows-window 2";
+          alt-shift-3 = "move-node-to-workspace --focus-follows-window 3";
+          alt-shift-4 = "move-node-to-workspace --focus-follows-window 4";
+          alt-shift-5 = "move-node-to-workspace --focus-follows-window 5";
+          alt-shift-6 = "move-node-to-workspace --focus-follows-window 6";
+          alt-shift-7 = "move-node-to-workspace --focus-follows-window 7";
+          alt-shift-8 = "move-node-to-workspace --focus-follows-window 8";
+          alt-shift-9 = "move-node-to-workspace --focus-follows-window 9";
+          alt-shift-0 = "move-node-to-workspace --focus-follows-window 10";
+        };
+      };
+    };
+  };
+}

--- a/modules/home/app/dev/claude-code/default.nix
+++ b/modules/home/app/dev/claude-code/default.nix
@@ -21,9 +21,8 @@ in {
       pkgs.nodejs
       pkgs.python3
       pkgs.uv
-      pkgs.bubblewrap
       pkgs.socat
-    ];
+    ] ++ lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.bubblewrap;
 
     home.sessionPath = ["$HOME/.local/bin" "$HOME/.npm-global/bin"];
 

--- a/modules/home/app/dev/devbox/direnv.nix
+++ b/modules/home/app/dev/devbox/direnv.nix
@@ -3,6 +3,7 @@
     enable = true;
     enableZshIntegration = true;
     nix-direnv.enable = true;
+    package = pkgs.direnv.overrideAttrs (_: {doCheck = false;});
   };
 
   capybara.impermanence.directories = [

--- a/modules/home/app/dev/devbox/direnv.nix
+++ b/modules/home/app/dev/devbox/direnv.nix
@@ -1,10 +1,19 @@
-{pkgs, ...}: {
-  programs.direnv = {
-    enable = true;
-    enableZshIntegration = true;
-    nix-direnv.enable = true;
-    package = pkgs.direnv.overrideAttrs (_: {doCheck = false;});
-  };
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  programs.direnv =
+    {
+      enable = true;
+      enableZshIntegration = true;
+      nix-direnv.enable = true;
+    }
+    // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+      # The fish test phase OOMs on darwin; skip tests there to keep the build
+      # from getting killed.
+      package = pkgs.direnv.overrideAttrs (_: {doCheck = false;});
+    };
 
   capybara.impermanence.directories = [
     ".local/share/direnv"

--- a/systems/aarch64-darwin/TMEN0081/default.nix
+++ b/systems/aarch64-darwin/TMEN0081/default.nix
@@ -1,0 +1,42 @@
+{lib, ...}:
+with lib;
+with lib.capybara; {
+  imports = [./keyboard.nix];
+
+  config = {
+    nix.enable = false;
+
+    homebrew = {
+      enable = true;
+      casks = [
+        "vivaldi"
+        "postman"
+        "sequel-ace"
+        "ukelele"
+      ];
+    };
+    system.primaryUser = "usr0200797";
+
+    capybara = {
+      app.dev.docker = enabled;
+      system.fonts = enabled;
+      windowManager.aerospace = enabled;
+    };
+
+    system = {
+      defaults = {
+        NSGlobalDomain = {
+          AppleInterfaceStyle = "Dark";
+          "com.apple.mouse.tapBehavior" = 1;
+        };
+        dock.autohide = true;
+      };
+      keyboard = {
+        enableKeyMapping = true;
+        swapLeftCtrlAndFn = true;
+      };
+    };
+
+    system.stateVersion = 5;
+  };
+}

--- a/systems/aarch64-darwin/TMEN0081/keyboard.nix
+++ b/systems/aarch64-darwin/TMEN0081/keyboard.nix
@@ -1,0 +1,536 @@
+{lib, ...}:
+with lib;
+with lib.capybara; {
+  system.defaults.CustomUserPreferences."com.apple.symbolichotkeys".AppleSymbolicHotkeys = {
+    "10" = {
+      enabled = false;
+      value = {
+        parameters = [65535 96 8650752];
+        type = "standard";
+      };
+    };
+    "11" = {
+      enabled = false;
+      value = {
+        parameters = [65535 97 8650752];
+        type = "standard";
+      };
+    };
+    "118" = {
+      enabled = false;
+      value = {
+        parameters = [65535 18 262144];
+        type = "standard";
+      };
+    };
+    "119" = {
+      enabled = false;
+      value = {
+        parameters = [65535 19 262144];
+        type = "standard";
+      };
+    };
+    "12" = {
+      enabled = false;
+      value = {
+        parameters = [65535 122 8650752];
+        type = "standard";
+      };
+    };
+    "120" = {
+      enabled = false;
+      value = {
+        parameters = [65535 20 262144];
+        type = "standard";
+      };
+    };
+    "121" = {
+      enabled = false;
+      value = {
+        parameters = [65535 21 262144];
+        type = "standard";
+      };
+    };
+    "122" = {
+      enabled = false;
+      value = {
+        parameters = [65535 23 262144];
+        type = "standard";
+      };
+    };
+    "123" = {
+      enabled = false;
+      value = {
+        parameters = [65535 22 262144];
+        type = "standard";
+      };
+    };
+    "124" = {
+      enabled = false;
+      value = {
+        parameters = [65535 26 262144];
+        type = "standard";
+      };
+    };
+    "125" = {
+      enabled = false;
+      value = {
+        parameters = [65535 28 262144];
+        type = "standard";
+      };
+    };
+    "126" = {
+      enabled = false;
+      value = {
+        parameters = [65535 25 262144];
+        type = "standard";
+      };
+    };
+    "127" = {
+      enabled = false;
+      value = {
+        parameters = [65535 29 262144];
+        type = "standard";
+      };
+    };
+    "13" = {
+      enabled = false;
+      value = {
+        parameters = [65535 98 8650752];
+        type = "standard";
+      };
+    };
+    "15" = {
+      enabled = false;
+      value = {
+        parameters = [56 28 1572864];
+        type = "standard";
+      };
+    };
+    "156" = {
+      enabled = true;
+      value = {
+        parameters = [65535 49 393216];
+        type = "standard";
+      };
+    };
+    "16" = {enabled = false;};
+    "162" = {
+      enabled = false;
+      value = {
+        parameters = [65535 96 9961472];
+        type = "standard";
+      };
+    };
+    "164" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "17" = {
+      enabled = false;
+      value = {
+        parameters = [94 24 1572864];
+        type = "standard";
+      };
+    };
+    "175" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "18" = {enabled = false;};
+    "184" = {
+      enabled = false;
+      value = {
+        parameters = [53 23 1179648];
+        type = "standard";
+      };
+    };
+    "19" = {
+      enabled = false;
+      value = {
+        parameters = [45 27 1572864];
+        type = "standard";
+      };
+    };
+    "190" = {
+      enabled = false;
+      value = {
+        parameters = [113 12 8388608];
+        type = "standard";
+      };
+    };
+    "20" = {enabled = false;};
+    "21" = {
+      enabled = false;
+      value = {
+        parameters = [56 28 1835008];
+        type = "standard";
+      };
+    };
+    "22" = {enabled = false;};
+    "222" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "223" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "224" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "225" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "226" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "227" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "228" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "229" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "23" = {
+      enabled = false;
+      value = {
+        parameters = [165 93 1572864];
+        type = "standard";
+      };
+    };
+    "230" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "231" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "232" = {
+      enabled = false;
+      value = {
+        parameters = [65535 65535 0];
+        type = "standard";
+      };
+    };
+    "24" = {enabled = false;};
+    "25" = {
+      enabled = false;
+      value = {
+        parameters = [46 47 1835008];
+        type = "standard";
+      };
+    };
+    "26" = {
+      enabled = false;
+      value = {
+        parameters = [44 43 1835008];
+        type = "standard";
+      };
+    };
+    "27" = {
+      enabled = false;
+      value = {
+        parameters = [64 33 1048576];
+        type = "standard";
+      };
+    };
+    "28" = {
+      enabled = false;
+      value = {
+        parameters = [51 20 1179648];
+        type = "standard";
+      };
+    };
+    "29" = {
+      enabled = false;
+      value = {
+        parameters = [51 20 1441792];
+        type = "standard";
+      };
+    };
+    "30" = {
+      enabled = false;
+      value = {
+        parameters = [52 21 1179648];
+        type = "standard";
+      };
+    };
+    "31" = {
+      enabled = true;
+      value = {
+        parameters = [115 1 655360];
+        type = "standard";
+      };
+    };
+    "32" = {
+      enabled = false;
+      value = {
+        parameters = [65535 126 10747904];
+        type = "standard";
+      };
+    };
+    "33" = {
+      enabled = false;
+      value = {
+        parameters = [65535 125 10747904];
+        type = "standard";
+      };
+    };
+    "34" = {
+      enabled = true;
+      value = {
+        parameters = [65535 126 2490368];
+        type = "standard";
+      };
+    };
+    "35" = {
+      enabled = true;
+      value = {
+        parameters = [65535 125 2490368];
+        type = "standard";
+      };
+    };
+    "36" = {
+      enabled = false;
+      value = {
+        parameters = [65535 103 8388608];
+        type = "standard";
+      };
+    };
+    "37" = {
+      enabled = true;
+      value = {
+        parameters = [65535 103 131072];
+        type = "standard";
+      };
+    };
+    "51" = {
+      enabled = true;
+      value = {
+        parameters = [64 33 1572864];
+        type = "standard";
+      };
+    };
+    "52" = {
+      enabled = false;
+      value = {
+        parameters = [100 2 1572864];
+        type = "standard";
+      };
+    };
+    "53" = {
+      enabled = true;
+      value = {
+        parameters = [65535 107 0];
+        type = "standard";
+      };
+    };
+    "54" = {
+      enabled = true;
+      value = {
+        parameters = [65535 113 0];
+        type = "standard";
+      };
+    };
+    "55" = {
+      enabled = true;
+      value = {
+        parameters = [65535 107 524288];
+        type = "standard";
+      };
+    };
+    "56" = {
+      enabled = true;
+      value = {
+        parameters = [65535 113 524288];
+        type = "standard";
+      };
+    };
+    "57" = {
+      enabled = false;
+      value = {
+        parameters = [65535 100 8650752];
+        type = "standard";
+      };
+    };
+    "59" = {
+      enabled = false;
+      value = {
+        parameters = [65535 96 9437184];
+        type = "standard";
+      };
+    };
+    "60" = {
+      enabled = true;
+      value = {
+        parameters = [32 49 262144];
+        type = "standard";
+      };
+    };
+    "61" = {
+      enabled = false;
+      value = {
+        parameters = [32 49 786432];
+        type = "standard";
+      };
+    };
+    "62" = {
+      enabled = true;
+      value = {
+        parameters = [65535 111 0];
+        type = "standard";
+      };
+    };
+    "63" = {
+      enabled = true;
+      value = {
+        parameters = [65535 111 131072];
+        type = "standard";
+      };
+    };
+    "64" = {
+      enabled = true;
+      value = {
+        parameters = [65535 49 1048576];
+        type = "standard";
+      };
+    };
+    "65" = {
+      enabled = false;
+      value = {
+        parameters = [65535 49 1572864];
+        type = "standard";
+      };
+    };
+    "7" = {
+      enabled = false;
+      value = {
+        parameters = [65535 120 8650752];
+        type = "standard";
+      };
+    };
+    "70" = {
+      enabled = true;
+      value = {
+        parameters = [100 2 1310720];
+        type = "standard";
+      };
+    };
+    "73" = {
+      enabled = true;
+      value = {
+        parameters = [65535 53 1048576];
+        type = "standard";
+      };
+    };
+    "75" = {
+      enabled = false;
+      value = {
+        parameters = [65535 100 0];
+        type = "standard";
+      };
+    };
+    "76" = {
+      enabled = false;
+      value = {
+        parameters = [65535 100 131072];
+        type = "standard";
+      };
+    };
+    "79" = {
+      enabled = false;
+      value = {
+        parameters = [65535 123 8650752];
+        type = "standard";
+      };
+    };
+    "8" = {
+      enabled = false;
+      value = {
+        parameters = [65535 99 8650752];
+        type = "standard";
+      };
+    };
+    "80" = {
+      enabled = true;
+      value = {
+        parameters = [65535 123 8781824];
+        type = "standard";
+      };
+    };
+    "81" = {
+      enabled = false;
+      value = {
+        parameters = [65535 124 8650752];
+        type = "standard";
+      };
+    };
+    "82" = {
+      enabled = true;
+      value = {
+        parameters = [65535 124 8781824];
+        type = "standard";
+      };
+    };
+    "9" = {
+      enabled = false;
+      value = {
+        parameters = [65535 118 8650752];
+        type = "standard";
+      };
+    };
+    "98" = {
+      enabled = false;
+      value = {
+        parameters = [47 44 1179648];
+        type = "standard";
+      };
+    };
+  };
+}

--- a/systems/aarch64-darwin/TMEN0081/symbolichotkeys2nix.py
+++ b/systems/aarch64-darwin/TMEN0081/symbolichotkeys2nix.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import plistlib
+import json
+import subprocess
+
+if __name__ == '__main__':
+    home = os.environ['HOME']
+    p1 = subprocess.run(['/usr/libexec/PlistBuddy', '-c', 'Print :AppleSymbolicHotKeys', '-x', f'{home}/Library/Preferences/com.apple.symbolichotkeys.plist'], capture_output=True, text=True)
+    plist_text = p1.stdout
+    plist = plistlib.loads(plist_text)
+    json_text = json.dumps(plist, ensure_ascii=False)
+    p2 = subprocess.run(['nix-instantiate', '--arg-from-stdin', 'stdin', '--eval', '-E', '{ stdin }: builtins.fromJSON stdin'], input=json_text, capture_output=True, text=True)
+    nix_text = p2.stdout
+    print(nix_text)


### PR DESCRIPTION
## Summary
- Add `nix-darwin` flake input and the `aerospace`, `fonts`, `docker`, `zsh` reusable darwin modules.
- Add `TMEN0081` aarch64-darwin host (system + home for `usr0200797`); single-host homebrew apps (vivaldi, postman, sequel-ace, ukelele) inlined per the project's "no needless modularization" rule.
- Darwin-compat fixes to shared home modules: skip `bubblewrap` on darwin (claude-code), skip flaky direnv test suite on darwin only.

Spec: `docs/superpowers/specs/2026-04-28-merge-confidential-nix-config-design.md`
Plan: `docs/superpowers/plans/2026-04-28-merge-confidential-nix-config.md`

## Test plan
- [x] `darwin-rebuild build --flake .#TMEN0081` succeeds on TMEN0081
- [ ] `darwin-rebuild switch --flake .#TMEN0081` and verify aerospace/kitty/git/tmux work
- [ ] linux hosts (`helios`, `m5p01`, `xanthus`) still rebuild cleanly (no module changes affecting them beyond darwin-gated overrides)
- [ ] After merge: archive `mtaku3/confidential-nix-config`